### PR TITLE
修复因边距设置不足导致的正文内容越界覆盖到页眉的问题

### DIFF
--- a/preset/customstyle.cls
+++ b/preset/customstyle.cls
@@ -73,12 +73,12 @@
 \RequirePackage{geometry}
 \newgeometry{
     top=30mm, bottom=25mm, left=30mm, right=20mm,
-    headsep=5mm, includefoot
+    headsep=15mm, includefoot
 }
 \savegeometry{bachelorgeometry}
 \newgeometry{
     top=25mm, bottom=25mm, left=30mm, right=20mm,
-    headsep=5mm, headheight=10mm, footskip=10mm,
+    headsep=15mm, headheight=10mm, footskip=10mm,
 }
 \savegeometry{mastergeometry}
 


### PR DESCRIPTION
更改preset/customstyle.cls中第76行和第81行的headsep设置为15mm可以解决该问题。